### PR TITLE
Bugfix/skills animation hover override

### DIFF
--- a/src/components/SkillsCard/SkillsCard.module.scss
+++ b/src/components/SkillsCard/SkillsCard.module.scss
@@ -1,17 +1,6 @@
 //SkillsCard.module.scss
 @import '../../styles/abstracts';
 
-
-// Define the keyframes for the fade-in animation
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
 // Define the keyframes for the fade-in-up animation
 @keyframes fadeInUp {
     from {
@@ -24,7 +13,6 @@
     }
 }
 
-
 .skillsCard {
     background-color: var(--card-bg);
     color: var(--card-text);
@@ -33,9 +21,6 @@
     box-shadow: var(--card-box-shadow);
     padding: var(--spacing-md);
     margin-bottom: var(--spacing-lg);
-     // Initial state before animation
-    opacity: 0;
-    animation: fadeIn 0.8s ease-in forwards;
 }
 
 .title {
@@ -57,6 +42,7 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    animation: fadeInUp 0.5s ease-out forwards; // Animate the entire list
 }
 
 .item {
@@ -73,11 +59,12 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     border-radius: var(--border-radius-sm);
     background-color: var(--color-surface-elevated);
+    cursor: pointer;
 
-    // Initial state before animation
-    opacity: 0; 
-    transform: translateY(20px); 
-    animation: fadeInUp 0.5s ease-out forwards;
+    &:hover {
+        transform: translateY(-5px);
+        box-shadow: var(--box-shadow-md);
+    }
 }
 
 .iconWrapper {
@@ -141,12 +128,10 @@
 //  Staggered animation for list items
 // ==============================================
 @for $i from 1 through 50 {
-    // Apply a delay to each item using its position
     .list > :nth-child(#{$i}) {
-        animation-delay: ($i * 0.05s) + 0.1s; // Adjust the 0.05s for a faster or slower stagger
+        animation-delay: ($i * 0.05s) + 0.1s;
     }
 }
-
 
 // ==============================================
 //  Responsive adjustments

--- a/src/components/SkillsCard/SkillsCard.module.scss
+++ b/src/components/SkillsCard/SkillsCard.module.scss
@@ -7,6 +7,7 @@
         opacity: 0;
         transform: translateY(20px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -59,11 +60,12 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     border-radius: var(--border-radius-sm);
     background-color: var(--color-surface-elevated);
-    cursor: pointer;
+
 
     &:hover {
         transform: translateY(-5px);
-        box-shadow: var(--box-shadow-md);
+        //box-shadow: var(--box-shadow-hover-md); //Box shadow on hover will not work here, will be applied in modifier classes
+
     }
 }
 
@@ -95,11 +97,16 @@
 .skillsCard--major {
     .item {
         box-shadow: var(--box-shadow-skill-major);
+
+        &:hover {
+            box-shadow: var(--box-shadow-hover-md);
+        }
     }
 
     .iconWrapper {
         width: 64px;
         height: 64px;
+
         svg {
             fill: var(--color-brand-primary);
         }
@@ -116,6 +123,10 @@
 .skillsCard--other {
     .item {
         box-shadow: var(--box-shadow-skill-other);
+
+        &:hover {
+            box-shadow: var(--box-shadow-hover-sm);
+        }
     }
 
     .iconWrapper {
@@ -128,7 +139,7 @@
 //  Staggered animation for list items
 // ==============================================
 @for $i from 1 through 50 {
-    .list > :nth-child(#{$i}) {
+    .list> :nth-child(#{$i}) {
         animation-delay: ($i * 0.05s) + 0.1s;
     }
 }

--- a/src/styles/_abstracts.scss
+++ b/src/styles/_abstracts.scss
@@ -51,6 +51,16 @@
   --box-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
   --box-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
 
+/* --- New Hover Box Shadows (light theme) (based on 5px offset and 15px blur) --- */
+  // The '5px' offset becomes our base unit for the scales.
+  --box-shadow-hover-xxs: 1px 1px 3px rgba(0, 0, 0, 0.1), -1px -1px 3px rgba(0, 0, 0, 0.1), -1px 1px 3px rgba(0, 0, 0, 0.1), 1px -1px 3px rgba(0, 0, 0, 0.1);
+  --box-shadow-hover-xs: 2px 2px 6px rgba(0, 0, 0, 0.1), -2px -2px 6px rgba(0, 0, 0, 0.1), -2px 2px 6px rgba(0, 0, 0, 0.1), 2px -2px 6px rgba(0, 0, 0, 0.1);
+  --box-shadow-hover-sm: 3px 3px 9px rgba(0, 0, 0, 0.15), -3px -3px 9px rgba(0, 0, 0, 0.15), -3px 3px 9px rgba(0, 0, 0, 0.15), 3px -3px 9px rgba(0, 0, 0, 0.15);
+  --box-shadow-hover-md: 5px 5px 15px rgba(0, 0, 0, 0.2), -5px -5px 15px rgba(0, 0, 0, 0.2), -5px 5px 15px rgba(0, 0, 0, 0.2), 5px -5px 15px rgba(0, 0, 0, 0.2);
+  --box-shadow-hover-lg: 7px 7px 21px rgba(0, 0, 0, 0.25), -7px -7px 21px rgba(0, 0, 0, 0.25), -7px 7px 21px rgba(0, 0, 0, 0.25), 7px -7px 21px rgba(0, 0, 0, 0.25);
+  --box-shadow-hover-xl: 10px 10px 30px rgba(0, 0, 0, 0.3), -10px -10px 30px rgba(0, 0, 0, 0.3), -10px 10px 30px rgba(0, 0, 0, 0.3), 10px -10px 30px rgba(0, 0, 0, 0.3);
+  --box-shadow-hover-xxl: 15px 15px 45px rgba(0, 0, 0, 0.35), -15px -15px 45px rgba(0, 0, 0, 0.35), -15px 15px 45px rgba(0, 0, 0, 0.35), 15px -15px 45px rgba(0, 0, 0, 0.35);
+
  /* --- Box ShadowsBox for skills --- */
   --box-shadow-skill-major: 0 4px 12px rgba(0, 0, 0, 0.15);
   --box-shadow-skill-other: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -123,6 +133,17 @@
   /* --- Hero Section (Dark theme overrides) --- */
   --hero-bg: var(--color-surface-base);
   --hero-text: var(--color-text-primary);
+
+ /* --- New Hover Box Shadows (Dark theme overrides) --- */
+  // Use a less intense or different color for the dark theme.
+  --box-shadow-hover-xxs: 1px 1px 3px rgba(255, 255, 255, 0.1), -1px -1px 3px rgba(255, 255, 255, 0.1), -1px 1px 3px rgba(255, 255, 255, 0.1), 1px -1px 3px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-xs: 2px 2px 6px rgba(255, 255, 255, 0.1), -2px -2px 6px rgba(255, 255, 255, 0.1), -2px 2px 6px rgba(255, 255, 255, 0.1), 2px -2px 6px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-sm: 3px 3px 9px rgba(255, 255, 255, 0.1), -3px -3px 9px rgba(255, 255, 255, 0.1), -3px 3px 9px rgba(255, 255, 255, 0.1), 3px -3px 9px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-md: 5px 5px 15px rgba(255, 255, 255, 0.1), -5px -5px 15px rgba(255, 255, 255, 0.1), -5px 5px 15px rgba(255, 255, 255, 0.1), 5px -5px 15px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-lg: 7px 7px 21px rgba(255, 255, 255, 0.1), -7px -7px 21px rgba(255, 255, 255, 0.1), -7px 7px 21px rgba(255, 255, 255, 0.1), 7px -7px 21px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-xl: 10px 10px 30px rgba(255, 255, 255, 0.1), -10px -10px 30px rgba(255, 255, 255, 0.1), -10px 10px 30px rgba(255, 255, 255, 0.1), 10px -10px 30px rgba(255, 255, 255, 0.1);
+  --box-shadow-hover-xxl: 15px 15px 45px rgba(255, 255, 255, 0.1), -15px -15px 45px rgba(255, 255, 255, 0.1), -15px 15px 45px rgba(255, 255, 255, 0.1), 15px -15px 45px rgba(255, 255, 255, 0.1);
+
 
    /* --- Box ShadowsBox for skills (Dark theme overrides) --- */
   --box-shadow-skill-major: 0 4px 12px rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
fix(skills): Fix hover box shadow and update variables

Resolves a bug where the box-shadow was not applying on hover for skill items due to the animation interfering with the transition.

- Adds new scaled box-shadow variables for hover effects in abstracts.scss.
- Updates the hover styles in SkillsCard.module.scss to correctly apply the box-shadow from the new CSS variables.