### PR TITLE
docs: Update homepage text for hero and about sections

### DIFF
--- a/src/components/previews/AboutPreview/AboutPreview.jsx
+++ b/src/components/previews/AboutPreview/AboutPreview.jsx
@@ -16,7 +16,7 @@ const AboutPreview = () => {
           <h2 className={styles.aboutPreview__heading}>About Me</h2>
 
           <p className={styles.aboutPreview__text}>
-            As a Front-End Engineer with {yearsOfExperience}+ years of experience, I am passionate about Accessibility, SEO, Responsive Web Design, clean code, and creating intuitive UIs using modern frameworks and best practices.
+            As a Front-End Engineer with {yearsOfExperience}+ years of experience, I am passionate about Accessibility, SEO, Responsive Web Design, clean code, and creating intuitive UIs using Typescript, React.js and Next.js.
           </p>
 
           <Link

--- a/src/data/hero.js
+++ b/src/data/hero.js
@@ -7,16 +7,16 @@ export const heroData = {
   name: 'Bonaventure C.J. Ugwu',
   title: 'Front-End Engineer (React.js | Next.js | TypeScript)',
   description:
-    'Front-end Developer and Open-Source Contributor talented in building performant, maintainable and scalable web applications using React.js, Next.js, and TypeScript.',
+    'Front-end Developer and Open-Source Contributor talented in building performant, maintainable and scalable web applications using modern frameworks and best practices.',
   primaryCta: {
     label: "View My Work",
-    ariaLabel: "Navigate to Bonaventure's public projects page", // Add a more descriptive accessible name
+    ariaLabel: "Navigate to Bonaventure's public projects page", 
     title: "Navigate to Bonaventure's public projects page",
     url: '/projects',
   },
   secondaryCta: {
     label: "Download Resume",
-    ariaLabel: "Download Bonaventure's resume in PDF format", // Add a more descriptive accessible name
+    ariaLabel: "Download Bonaventure's resume in PDF format",
     title: "Download Bonaventure's resume (PDF)",
     url: requestResume,
   },


### PR DESCRIPTION


Update the text content for the homepage to reflect refined messaging in the hero and about-preview sections.